### PR TITLE
feat: add industries content structure

### DIFF
--- a/src/components/ui/Navbar.astro
+++ b/src/components/ui/Navbar.astro
@@ -109,7 +109,7 @@ const navButton = {
                           {item.dropdownContent.map((subItem, _) => (
                             <a
                               href={`/fjelltopp-astro${item.href}/${subItem.id}`}
-                              class="mobile-nav-link block rounded text-[var(--dark)] lg:flex-grow hover:bg-[var(--dark)] hover:text-white ml-4 lg:ml-0 lg:bg-transparent lg:p-1 lg:w-64"
+                              class="mobile-nav-link block rounded text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white ml-4 lg:ml-0 lg:bg-transparent lg:p-1 lg:w-64"
                               data-close-menu="true"
                             >
                               {subItem.data.title}

--- a/src/components/ui/Navbar.astro
+++ b/src/components/ui/Navbar.astro
@@ -107,7 +107,7 @@ const navButton = {
                           {item.dropdownContent.map((subItem, _) => (
                             <a
                               href={`/fjelltopp-astro${item.href}/${subItem.id}`}
-                              class="mobile-nav-link block rounded text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white sm:ml-4 md:ml-4 lg:ml-0 lg:bg-transparent lg:p-1"
+                              class="mobile-nav-link block rounded text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white ml-4 lg:ml-0 lg:bg-transparent lg:p-1"
                               data-close-menu="true"
                             >
                               {subItem.data.title}

--- a/src/components/ui/Navbar.astro
+++ b/src/components/ui/Navbar.astro
@@ -17,6 +17,13 @@ const allServices: CollectionEntry<"services">[] = (
     a.data.order - b.data.order,
 );
 
+const allIndustries: CollectionEntry<"industries">[] = (
+  await getCollection("industries")
+).sort(
+  (a: CollectionEntry<"industries">, b: CollectionEntry<"industries">) =>
+    a.data.order - b.data.order,
+);
+
 const menuitems = [
   { href: "/about", label: "About us", dropdown: false, dropdownContent: [] },
   {
@@ -25,7 +32,13 @@ const menuitems = [
     dropdown: true,
     dropdownContent: allServices,
   },
-  { href: "/#cases", label: "Use Cases", dropdown: false, dropdownContent: [] },
+  {
+    href: "/industries",
+    label: "Industries",
+    dropdown: true,
+    dropdownContent: allIndustries,
+  },
+  // { href: "/#cases", label: "Use Cases", dropdown: false, dropdownContent: [] },
   { href: "/pricing", label: "Pricing", dropdown: false, dropdownContent: [] },
   { href: "/articles", label: "Blog", dropdown: false, dropdownContent: [] },
 ];

--- a/src/components/ui/Navbar.astro
+++ b/src/components/ui/Navbar.astro
@@ -38,7 +38,7 @@ const menuitems = [
     dropdown: true,
     dropdownContent: allIndustries,
   },
-  // { href: "/#cases", label: "Use Cases", dropdown: false, dropdownContent: [] },
+  { href: "/#cases", label: "Use Cases", dropdown: false, dropdownContent: [] },
   { href: "/pricing", label: "Pricing", dropdown: false, dropdownContent: [] },
   { href: "/articles", label: "Blog", dropdown: false, dropdownContent: [] },
 ];
@@ -69,7 +69,7 @@ const navButton = {
 
         <MenuItems class="mt-2 hidden w-full lg:mt-0 lg:flex lg:w-auto">
           <ul
-            class="mt-4 flex flex-col rounded-lg border font-medium lg:mt-0 lg:flex-row lg:space-x-8 lg:border-0 lg:p-0"
+            class="mt-4 flex flex-col rounded-lg border lg:items-end font-medium lg:mt-0 lg:flex-row lg:space-x-4 lg:border-0 lg:p-0"
           >
             {
               menuitems.map((item, _) => (
@@ -77,15 +77,15 @@ const navButton = {
                   {!item.dropdown ? (
                     <a
                       href={`/fjelltopp-astro${item.href}`}
-                      class="mobile-nav-link block rounded text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white lg:bg-transparent lg:p-1"
+                      class="mobile-nav-link block rounded mx-0 lg:mx-2 text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white lg:bg-transparent lg:p-1"
                       data-close-menu="true"
                     >
                       {item.label}
                     </a>
                   ) : (
-                    <Dropdown class="group">
+                    <Dropdown class="group relative">
                       <button
-                        class="mobile-nav-link block rounded text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white lg:bg-transparent lg:p-1"
+                        class="mobile-nav-link block rounded mx-0 lg:mx-2 text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white lg:bg-transparent lg:p-1"
                         style="display: flex; align-items: center; gap: 2px;"
                       >
                         <span>{item.label}</span>
@@ -103,11 +103,13 @@ const navButton = {
                         </svg>
                       </button>
                       <DropdownItems>
-                        <div class="rounded bg-white lg:absolute lg:top-0 lg:mt-[71px]">
+                        <div
+                          class="rounded bg-white lg:bg-white/80 lg:absolute lg:overflow-auto"
+                        >
                           {item.dropdownContent.map((subItem, _) => (
                             <a
                               href={`/fjelltopp-astro${item.href}/${subItem.id}`}
-                              class="mobile-nav-link block rounded text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white ml-4 lg:ml-0 lg:bg-transparent lg:p-1"
+                              class="mobile-nav-link block rounded text-[var(--dark)] lg:flex-grow hover:bg-[var(--dark)] hover:text-white ml-4 lg:ml-0 lg:bg-transparent lg:p-1 lg:w-64"
                               data-close-menu="true"
                             >
                               {subItem.data.title}
@@ -122,7 +124,7 @@ const navButton = {
             }
             <div class="mt-3 flex items-center justify-center gap-4 lg:hidden">
               <a
-                class="mobile-nav-link inline-flex rounded-2xl border border-[var(--dark)] bg-white px-9 py-5 text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white"
+                class="mobile-nav-link inline-flex rounded-2xl border border-[var(--dark)] bg-white px-3 py-3 text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white"
                 href={navButton.href}
                 data-close-menu="true"
               >
@@ -138,7 +140,7 @@ const navButton = {
       <div>
         <div class="hidden items-center gap-4 lg:flex">
           <a
-            class="inline-flex rounded-2xl border border-[var(--dark)] bg-white px-9 py-5 text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white"
+            class="inline-flex rounded-2xl border border-[var(--dark)] bg-white px-3 py-3 text-[var(--dark)] hover:bg-[var(--dark)] hover:text-white"
             href={navButton.href}
           >
             <h2 class="text-center text-xl font-normal leading-7">

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -21,6 +21,7 @@ const industries = defineCollection({
   loader: glob({ pattern: "[^_]*.{md,mdx}", base: "src/content/industries" }),
   schema: z.object({
     title: z.string(),
+    order: z.number(),
     image: z.string(),
     summary: z.string(),
     language: z.enum(["en", "fr"]),

--- a/src/content/industries/health-services.md
+++ b/src/content/industries/health-services.md
@@ -1,0 +1,10 @@
+---
+title: "Health sector"
+order: 1
+summary: "A summary of things to say"
+image: ../../assets/pics/card-pic2.png
+type: "Industry"
+language: "en"
+---
+
+Here goes the body.

--- a/src/pages/industries/[...slug].astro
+++ b/src/pages/industries/[...slug].astro
@@ -6,8 +6,8 @@ import "../../styles/global.css";
 
 export async function getStaticPaths() {
   const allIndustries = await getCollection("industries");
-  return allIndustries.map((service) => ({
-    params: { slug: service.id },
+  return allIndustries.map((industry) => ({
+    params: { slug: industry.id },
   }));
 }
 

--- a/src/pages/industries/[...slug].astro
+++ b/src/pages/industries/[...slug].astro
@@ -1,0 +1,67 @@
+---
+import MainLayout from "../../layouts/MainLayout.astro";
+import { getCollection, getEntry, render } from "astro:content";
+
+import "../../styles/global.css";
+
+export async function getStaticPaths() {
+  const allIndustries = await getCollection("industries");
+  return allIndustries.map((service) => ({
+    params: { slug: service.id },
+  }));
+}
+
+const { slug } = Astro.params;
+
+if (slug === undefined) {
+  throw new Error("Slug is required");
+}
+
+const entry = await getEntry("industries", slug);
+
+if (entry === undefined) {
+  return Astro.redirect("/404");
+}
+
+const { Content } = await render(entry);
+---
+
+<MainLayout title={entry.data.title}>
+  <main class="mb-40 space-y-40 pt-24">
+    <section class="bg-white">
+      <div
+        class="mx-auto max-w-screen-xl items-center gap-16 px-4 py-8 lg:grid lg:grid-cols-1 lg:px-3 lg:py-16"
+      >
+        <div class="font-light text-gray-500 sm:text-lg">
+          <a
+            href="/fjelltopp-astro"
+            class="hover:text-green my-4 inline-flex items-center font-medium text-black"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              class="h-6 w-6"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M7 16l-4-4m0 0l4-4m-4 4h18"
+              >
+              </path>
+            </svg>
+            <span class="ml-1 text-lg font-bold">Back</span>
+          </a>
+          <h2 class="mb-4 text-4xl font-extrabold tracking-tight text-gray-900">
+            {entry.data.title}
+          </h2>
+          <div class="content">
+            <Content />
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+</MainLayout>


### PR DESCRIPTION
- Adds industries to the nav bar and sets up auto-generation of industries pages from markdown files.
- Fixes issues so the nav bar displays dropdowns correctly (and generally looks nice) when there are many items in the nav bar.
- Makes the "book a consultation" sign smaller.

Note the dropdowns have a defined with in large mode, to make sure the items don't split over two lines. I wanted a defined max-width, but I just couldn't get it to work...